### PR TITLE
SCRUM-98 timer no skippea si baja de 0

### DIFF
--- a/src/containers/TurnTimer/TurnTimer.jsx
+++ b/src/containers/TurnTimer/TurnTimer.jsx
@@ -22,7 +22,7 @@ const TurnTimer = ({ initialTime, playerId, gameId, isYourTurn }) => {
   }, [secondsLeft]);
 
   useEffect(() => {
-    if (secondsLeft === 0 && isYourTurn && !isLoading) {
+    if (secondsLeft <= 0 && isYourTurn && !isLoading) {
         handleEndTurn();
     }
   }, [secondsLeft, isYourTurn, isLoading]);


### PR DESCRIPTION
Cuando el jugador que tenia el turno activo cerraba la pagina y la volvía a abrir cuando ya pasaron 120 segundos, el back manda un turn timer negativo, lo cual no activa handleEndTurn y el turno termina siendo infinito